### PR TITLE
简化 Issue 模板，降低用户填写门槛

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,57 +1,41 @@
 name: 报告问题 / Bug Report
-description: 使用简练详细的语言描述你遇到的问题
+description: 遇到 Bug 或异常行为？告诉我发生了什么
 labels: ["bug"]
 body:
   - type: markdown
     attributes:
       value: |
-        感谢你花时间填写一份问题报告！请提供尽可能详细的信息，以便我们快速解决。
+        感谢你的反馈！填三项就够了，不用太正式。
+
+  - type: dropdown
+    id: category
+    attributes:
+      label: 问题类型
+      options:
+        - 程序崩溃 / 报错
+        - 功能不正常
+        - 激活 / 会员问题
+        - 更新问题
+        - 界面显示问题
+        - 其他
 
   - type: textarea
     id: description
     attributes:
-      label: 问题描述
-      description: 简洁且清晰地描述这个 Bug。
-      placeholder: 描述发生了什么...
-    validations:
-      required: true
-
-  - type: textarea
-    id: steps
-    attributes:
-      label: 复现步骤
-      description: 包含如何复现该问题的具体步骤。
+      label: 发生了什么
+      description: 描述问题，以及怎么触发的。如果和预期不一样，也可以顺带说说你期望的结果。
       placeholder: |
-        1. 进入 '...'
-        2. 点击 '...'
-        3. 发现错误
-    validations:
-      required: true
-
-  - type: textarea
-    id: expected
-    attributes:
-      label: 期望行为
-      description: 你期望发生什么？
-      placeholder: 描述期望的结果...
-    validations:
-      required: true
-
-  - type: textarea
-    id: actual
-    attributes:
-      label: 实际行为
-      description: 实际发生了什么？如果可以，请附上截图。
-      placeholder: 描述实际发生的情况...
+        我在做 ... 的时候，发现 ...
+        重现方式：1. ... 2. ... 3. ...
     validations:
       required: true
 
   - type: input
     id: version
     attributes:
-      label: 应用版本
-      description: 你当前运行的 Nebula Graph 版本？（可在设置中查看）
-      placeholder: 例如 v1.2.0
+      label: 版本号
+      description: 可在软件设置页面查看
+      placeholder: 例如 v0.6.2
     validations:
       required: true
 
@@ -62,16 +46,13 @@ body:
       options:
         - Windows 11
         - Windows 10
-        - macOS (Apple Silicon)
-        - macOS (Intel)
-        - Ubuntu / Debian
-        - Other
+        - 其他
     validations:
       required: true
 
   - type: textarea
     id: logs
     attributes:
-      label: 日志与输出
-      description: 请粘贴引擎日志或控制台报错（如有）。
+      label: 截图或日志（选填）
+      description: 如果有报错信息或截图，粘贴在这里会很有帮助。
       render: shell

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,39 +1,24 @@
-name: 功能请求 / Feature Request
-description: 提交一个新的功能建议
+name: 功能建议 / Feature Request
+description: 有个想法想让软件做到？说说看
 labels: ["enhancement"]
 body:
   - type: markdown
     attributes:
       value: |
-        感谢你为 Nebula Graph 提供反馈！
-
-  - type: textarea
-    id: motivation
-    attributes:
-      label: 需求背景
-      description: 你的功能请求是否与某个问题有关？请描述它。
-      placeholder: 当我尝试...时，我觉得不太方便。
-    validations:
-      required: true
+        不需要写方案，也不用想得很完整——把你想要的说清楚就好。
 
   - type: textarea
     id: feature
     attributes:
-      label: 功能描述
-      description: 详细描述你期望的功能或解决方案。
-      placeholder: 我希望 Nebula Graph 能够支持...
+      label: 你希望实现什么
+      description: 越具体越好。可以说说你现在是怎么做的，然后希望软件帮你做什么。
+      placeholder: 我现在需要手动做 ...，希望软件能够直接 ...
     validations:
       required: true
 
   - type: textarea
-    id: alternatives
-    attributes:
-      label: 备选方案
-      description: 你是否有考虑过其他的替代方案或实现方式？
-      placeholder: 我也考虑过...
-
-  - type: textarea
     id: context
     attributes:
-      label: 补充说明
-      description: 任何其他相关的背景信息、设计构思或截图。
+      label: 使用场景（选填）
+      description: 什么情况下你会用到这个功能？
+      placeholder: 比如在处理 ... 类型的数据时...


### PR DESCRIPTION
## 改动说明

### Bug Report
- 必填字段从 7 个减到 3 个
- 合并「问题描述 / 复现步骤 / 期望行为 / 实际行为」为一个引导式文本框，用 placeholder 引导用户说清楚就行
- 新增「问题类型」下拉（不强制），方便快速分类（崩溃 / 功能异常 / 激活问题 / 更新问题 / 界面问题）
- 去掉 macOS / Linux 系统选项，保留 Win10 / Win11 / 其他
- 日志/截图改为选填，措辞更友好

### Feature Request
- 字段从 4 个减到 2 个
- 删除「需求背景」和「备选方案」——这是工程师思维，普通用户不会这样组织想法
- 只留「你希望实现什么」（必填）和「使用场景」（选填）
- 措辞改成"说说看"，降低心理门槛

## 目标
让不熟悉 GitHub 的科研用户也愿意提 issue，而不是因为字段太多直接放弃。